### PR TITLE
Add basic JUnit testing structure

### DIFF
--- a/java/test/jmri/jmrix/cmri/serial/PackageTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/PackageTest.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
    jmri.jmrix.cmri.serial.configurexml.PackageTest.class,
    jmri.jmrix.cmri.serial.serialmon.PackageTest.class,
    jmri.jmrix.cmri.serial.nodeconfig.PackageTest.class,
+   jmri.jmrix.cmri.serial.nodeiolist.PackageTest.class,
    jmri.jmrix.cmri.serial.assignment.PackageTest.class,
    jmri.jmrix.cmri.serial.diagnostic.PackageTest.class,
    jmri.jmrix.cmri.serial.packetgen.PackageTest.class,

--- a/java/test/jmri/jmrix/cmri/serial/nodeiolist/NodeIOListFrameTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/nodeiolist/NodeIOListFrameTest.java
@@ -1,0 +1,39 @@
+package jmri.jmrix.cmri.serial.nodeiolist;
+
+import apps.tests.Log4JFixture;
+import jmri.util.JUnitUtil;
+import jmri.jmrix.cmri.CMRISystemConnectionMemo;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import java.awt.GraphicsEnvironment;
+
+/**
+ * Test simple functioning of NodeIOListFrame
+ *
+ * @author	Paul Bender Copyright (C) 2016
+ * @author	Bob Jacobsen Copyright (C) 2016
+ */
+public class NodeIOListFrameTest {
+
+    @Test
+    public void testMemoCtor() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        NodeIOListFrame action = new NodeIOListFrame(new CMRISystemConnectionMemo()); 
+        Assert.assertNotNull("exists", action);
+    }
+
+    @Before
+    public void setUp() {
+        Log4JFixture.setUp();
+        JUnitUtil.resetInstanceManager();
+    }
+
+    @After
+    public void tearDown() {
+        JUnitUtil.resetInstanceManager();
+        Log4JFixture.tearDown();
+    }
+}

--- a/java/test/jmri/jmrix/cmri/serial/nodeiolist/PackageTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/nodeiolist/PackageTest.java
@@ -1,0 +1,38 @@
+package jmri.jmrix.cmri.serial.nodeiolist;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+
+/**
+ * Tests for the jmri.jmrix.cmri.serial.nodeiolist package.
+ *
+ * @author Bob Jacobsen Copyright 2003, 2017
+ * @author Paul Bender Copyright (C) 2016
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+   jmri.jmrix.cmri.serial.nodeiolist.NodeIOListFrameTest.class,
+})
+
+public class PackageTest{
+
+    // Main entry point
+    static public void main(String[] args) {
+        org.junit.runner.Result result = org.junit.runner.JUnitCore
+                 .runClasses(PackageTest.class);
+        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
+            log.error(fail.toString());
+        }
+        //junit.textui.TestRunner.main(testCaseName);
+        if (result.wasSuccessful()) {
+            log.info("Success");
+        }
+    }
+
+    private final static Logger log = LoggerFactory.getLogger(PackageTest.class.getName());
+
+}


### PR DESCRIPTION
This adds the basic JUnit testing structure (a file for the package, and a place to put tests for the class) to your cmri.serial.nodeiolist package.  

@CCatania01 Please merge this, which adds this to your branch and PR.